### PR TITLE
Add scrolling map and smoother movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Prawn Stars
 
-Minimal top‑down shooter inspired by Brawl Stars.
+Minimal top-down shooter inspired by Brawl Stars.
 
 ## Running
 
-```
+```bash
 cd server
 npm start
 ```
@@ -17,6 +17,57 @@ Open `http://localhost:3000` in your browser. Connecting clients join the same a
 - **IJKL** – shoot in the four directions
 - **Space + IJKL** – grapple hook
 
-Each player has 10 HP. Taking damage lowers HP by 1. Killing another player heals you to full. Dying respawns you at a random location.
+Each player has 10 HP. Taking damage lowers HP by 1. Killing another player heals you to full. Dying respawns you at a random location. The map now scrolls with your character so only a small area is visible at once.
 
 Walls block bullets and can be grappled.
+
+## Developer Guide
+
+### Project layout
+
+```
+public/       - client side assets
+  index.html  - main game page
+  client.js   - browser logic and drawing
+  style.css   - basic styles
+  assets/     - sound effects
+server/       - Node.js backend
+  server.js   - HTTP server and event stream
+  game.js     - game state and rules
+  package.json
+```
+
+The server serves files from the `public` folder and exposes simple endpoints:
+
+- `POST /join` – register a new player and return the map
+- `GET /stream?id=<id>` – server-sent events stream with game state updates
+- `POST /action` – send player actions (`move`, `shoot`, `grapple`)
+
+Client logic in `public/client.js` uses these endpoints to join the game, listen for updates and send actions based on keyboard input.
+
+### Gameplay features
+
+- Randomly generated rectangular map with walls around the border
+- Four-directional movement and shooting
+- Simple collision, damage and respawn logic in `game.js`
+- Grapple hook that pulls the player next to the first wall in a direction
+- Basic sound effects and colored rectangles for graphics
+- Small death animation and visible health bars
+- Holding **space** shows the grappling hook range preview
+- Large scrolling map with camera centered on the player
+- Smooth movement between grid cells
+- Browser zoom keys are disabled so everyone sees the same area
+
+### Modifying the game
+
+- **Changing map size or density** – edit `MAP_WIDTH`, `MAP_HEIGHT` and map generation in `server/game.js`.
+- **Player properties and rules** – handled in `addPlayer`, `update` and `handleAction` inside `server/game.js`.
+- **Client rendering** – update canvas drawing code or add sprites in `public/client.js` and assets under `public/`.
+- **Camera behaviour** – the view follows the current player, computed in `draw()` inside `public/client.js`.
+- **Networking** – `server/server.js` streams the current state every 100ms. Adjust the interval or protocol here.
+- **Sounds and assets** – add files under `public/assets` and reference them from `public/client.js`.
+
+### Installation
+
+Only Node.js is required. The server has no external dependencies. In the `server` directory you can run `npm install` (creates a `package-lock.json` but installs nothing) then `npm start` to launch.
+

--- a/public/client.js
+++ b/public/client.js
@@ -6,29 +6,74 @@ let map = [];
 let players = {};
 let bullets = [];
 let lastHp = 10;
+const keys = {};
+const prevPlayers = {};
+let animations = [];
 const sndShoot = new Audio('assets/shoot.wav');
 const sndKill = new Audio('assets/kill.wav');
 const sndDie = new Audio('assets/die.wav');
 
 function draw() {
   ctx.clearRect(0,0,canvas.width,canvas.height);
-  for (let y=0;y<map.length;y++){
-    for(let x=0;x<map[y].length;x++){
-      if(map[y][x]===1){
+
+  const tilesX = canvas.width/tileSize;
+  const tilesY = canvas.height/tileSize;
+  const me = players[playerId];
+  let camX=0, camY=0;
+  if(me){
+    camX = me.x - tilesX/2;
+    camY = me.y - tilesY/2;
+    const maxX = map[0].length - tilesX;
+    const maxY = map.length - tilesY;
+    camX = Math.max(0, Math.min(camX, maxX));
+    camY = Math.max(0, Math.min(camY, maxY));
+  }
+
+  const startX = Math.floor(camX);
+  const startY = Math.floor(camY);
+
+  for (let y=startY; y<startY+tilesY+1; y++){
+    for(let x=startX; x<startX+tilesX+1; x++){
+      if(map[y] && map[y][x]===1){
         ctx.fillStyle='#555';
-        ctx.fillRect(x*tileSize,y*tileSize,tileSize,tileSize);
+        ctx.fillRect((x-camX)*tileSize,(y-camY)*tileSize,tileSize,tileSize);
       }
     }
   }
+
   for(const id in players){
     const p=players[id];
+    const px=(p.x - camX)*tileSize;
+    const py=(p.y - camY)*tileSize;
     ctx.fillStyle=id===playerId?'#0f0':'#f00';
-    ctx.fillRect(p.x*tileSize,p.y*tileSize,tileSize,tileSize);
+    ctx.beginPath();
+    ctx.arc(px, py, tileSize/2-2,0,Math.PI*2);
+    ctx.fill();
+    // health bar
+    ctx.fillStyle='#000';
+    ctx.fillRect(px - tileSize/2, py - tileSize/2 - 4, tileSize, 3);
+    ctx.fillStyle='#0f0';
+    ctx.fillRect(px - tileSize/2, py - tileSize/2 - 4, tileSize*(p.hp/10), 3);
   }
   ctx.fillStyle='#ff0';
   bullets.forEach(b=>{
-    ctx.fillRect(b.x*tileSize,b.y*tileSize,4,4);
+    ctx.fillRect((b.x - camX)*tileSize-2,(b.y - camY)*tileSize-2,4,4);
   });
+  // death animations
+  animations.forEach(a=>{
+    const alpha = 1 - a.t/10;
+    ctx.fillStyle = `rgba(255,255,255,${alpha})`;
+    ctx.beginPath();
+    ctx.arc((a.x - camX)*tileSize, (a.y - camY)*tileSize, tileSize*(a.t/10+0.5), 0, Math.PI*2);
+    ctx.fill();
+    a.t++;
+  });
+  animations = animations.filter(a=>a.t<10);
+
+  const me = players[playerId];
+  if(me && keys[' ']){
+    drawGrapplePreview(me, camX, camY);
+  }
   requestAnimationFrame(draw);
 }
 
@@ -37,7 +82,10 @@ function send(action){
 }
 
 function setupInput(){
-  const keys={};
+  window.addEventListener('keydown',e=>{
+    if(e.ctrlKey && ['-','_','+','=','0'].includes(e.key)) e.preventDefault();
+  });
+  window.addEventListener('wheel',e=>{ if(e.ctrlKey) e.preventDefault(); },{passive:false});
   document.addEventListener('keydown',e=>{keys[e.key]=true;});
   document.addEventListener('keyup',e=>{keys[e.key]=false;});
   setInterval(()=>{
@@ -61,6 +109,20 @@ function setupInput(){
   },100);
 }
 
+function drawGrapplePreview(me, camX, camY){
+  ctx.fillStyle='rgba(255,255,255,0.3)';
+  const dirs=[{x:0,y:-1},{x:0,y:1},{x:-1,y:0},{x:1,y:0}];
+  for(const d of dirs){
+    let cx=Math.floor(me.x), cy=Math.floor(me.y);
+    for(let i=0;i<5;i++){
+      cx+=d.x; cy+=d.y;
+      if(cx<0||cy<0||cx>=map[0].length||cy>=map.length) break;
+      ctx.fillRect((cx - camX)*tileSize+4, (cy - camY)*tileSize+4, tileSize-8, tileSize-8);
+      if(map[cy][cx]===1) break;
+    }
+  }
+}
+
 function start(){
   fetch('/join',{method:'POST'}).then(r=>r.json()).then(data=>{
     playerId=data.id; map=data.map;
@@ -68,6 +130,17 @@ function start(){
     es.onmessage=ev=>{
       const state=JSON.parse(ev.data);
       players=state.players;bullets=state.bullets;
+      for(const id in state.players){
+        const p=state.players[id];
+        const prev=prevPlayers[id];
+        if(prev && p.hp===10 && prev.hp<10 && (p.x!==prev.x || p.y!==prev.y)){
+          animations.push({x:prev.x,y:prev.y,t:0});
+        }
+        prevPlayers[id]={x:p.x,y:p.y,hp:p.hp};
+      }
+      for(const id in prevPlayers){
+        if(!state.players[id]) delete prevPlayers[id];
+      }
       const me=players[playerId];
       if(me){
         if(me.hp<lastHp) sndDie.play();

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>Prawn Stars</title>
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/server/game.js
+++ b/server/game.js
@@ -1,7 +1,9 @@
-const MAP_WIDTH = 50;
-const MAP_HEIGHT = 30;
+const MAP_WIDTH = 200;
+const MAP_HEIGHT = 200;
 const TILE_EMPTY = 0;
 const TILE_WALL = 1;
+const PLAYER_SPEED = 0.2;
+const BULLET_SPEED = 0.5;
 const players = {};
 const bullets = [];
 let nextPlayerId = 1;
@@ -25,7 +27,7 @@ function addPlayer() {
     y = Math.floor(Math.random() * MAP_HEIGHT);
   } while (map[y][x] !== TILE_EMPTY);
   const id = String(nextPlayerId++);
-  players[id] = {id, x, y, hp:10, score:0};
+  players[id] = {id, x: x + 0.5, y: y + 0.5, hp:10, score:0};
   return players[id];
 }
 function removePlayer(id) {
@@ -33,7 +35,7 @@ function removePlayer(id) {
 }
 function addBullet(ownerId, dir) {
   const owner = players[ownerId];
-  const speed = 1;
+  const speed = BULLET_SPEED;
   const vel = {x:0,y:0};
   if (dir==='up') vel.y=-speed;
   else if (dir==='down') vel.y=speed;
@@ -60,7 +62,7 @@ function update() {
             p.hp=10;
             let sx,sy;
             do{ sx=Math.floor(Math.random()*MAP_WIDTH); sy=Math.floor(Math.random()*MAP_HEIGHT);}while(map[sy][sx]!==TILE_EMPTY);
-            p.x=sx; p.y=sy;
+            p.x=sx+0.5; p.y=sy+0.5;
           }
           bullets.splice(i,1); break;
         }
@@ -73,7 +75,7 @@ function handleAction(id, action) {
   if (!p) return;
   if (action.type==='move') {
     const dx = action.dx||0; const dy=action.dy||0;
-    const nx = p.x + dx; const ny = p.y + dy;
+    const nx = p.x + dx * PLAYER_SPEED; const ny = p.y + dy * PLAYER_SPEED;
     if (nx>=0&&ny>=0&&nx<MAP_WIDTH&&ny<MAP_HEIGHT&&map[Math.floor(ny)][Math.floor(nx)]===TILE_EMPTY){
       p.x = nx; p.y = ny;
     }
@@ -83,8 +85,16 @@ function handleAction(id, action) {
     const dir=action.dir;
     let dx=0,dy=0;
     if(dir==='up')dy=-1;else if(dir==='down')dy=1;else if(dir==='left')dx=-1;else if(dir==='right')dx=1;
-    let cx=p.x,cy=p.y;
-    for(let i=0;i<5;i++){cx+=dx;cy+=dy;if(cx<0||cy<0||cx>=MAP_WIDTH||cy>=MAP_HEIGHT)break; if(map[Math.floor(cy)][Math.floor(cx)]===TILE_WALL){p.x=cx-dx;p.y=cy-dy;break;}}
+    let cx=Math.floor(p.x), cy=Math.floor(p.y);
+    for(let i=0;i<5;i++){
+      cx+=dx; cy+=dy;
+      if(cx<0||cy<0||cx>=MAP_WIDTH||cy>=MAP_HEIGHT)break;
+      if(map[cy][cx]===TILE_WALL){
+        p.x=cx-dx+0.5;
+        p.y=cy-dy+0.5;
+        break;
+      }
+    }
   }
 }
 function gameState(){


### PR DESCRIPTION
## Summary
- enlarge server map and track player positions with fractional coordinates
- update movement, grappling and bullets for new coordinate system
- render only the visible portion of the map and draw players as circles
- block browser zoom and prevent extra view
- document scrolling map and smooth movement

## Testing
- `npm test --silent` *(fails: Server running but network request blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852a81a3df08326bec1c1d01a60f8fb