### PR TITLE
Add YAML config for gameplay stats

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -17,6 +17,7 @@ const prevPlayers = {};
 let smoothPrev = {};
 let lastUpdate = Date.now();
 let animations = [];
+let config = {grappleRange:5};
 const sndShoot = new Audio('assets/shoot.wav');
 const sndKill = new Audio('assets/kill.wav');
 const sndDie = new Audio('assets/die.wav');
@@ -125,7 +126,7 @@ function drawGrapplePreview(me, camX, camY){
   const dirs=[{x:0,y:-1},{x:0,y:1},{x:-1,y:0},{x:1,y:0}];
   for(const d of dirs){
     let cx=Math.floor(me.x), cy=Math.floor(me.y);
-    for(let i=0;i<5;i++){
+    for(let i=0;i<(config.grappleRange||5);i++){
       cx+=d.x; cy+=d.y;
       if(cx<0||cy<0||cx>=map[0].length||cy>=map.length) break;
       ctx.fillRect((cx - camX)*tileSize+4, (cy - camY)*tileSize+4, tileSize-8, tileSize-8);
@@ -136,7 +137,7 @@ function drawGrapplePreview(me, camX, camY){
 
 function start(){
   fetch('/join',{method:'POST'}).then(r=>r.json()).then(data=>{
-    playerId=data.id; map=data.map;
+    playerId=data.id; map=data.map; config=data.config||config;
     const es=new EventSource('/stream?id='+playerId);
     es.onmessage=ev=>{
       const state=JSON.parse(ev.data);

--- a/server/config.yml
+++ b/server/config.yml
@@ -1,0 +1,3 @@
+playerSpeed: 0.2
+bulletSpeed: 0.5
+grappleRange: 5

--- a/server/game.js
+++ b/server/game.js
@@ -1,9 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
 const MAP_WIDTH = 200;
 const MAP_HEIGHT = 200;
 const TILE_EMPTY = 0;
 const TILE_WALL = 1;
-const PLAYER_SPEED = 0.2;
-const BULLET_SPEED = 0.5;
+
+function loadConfig() {
+  const file = path.join(__dirname, 'config.yml');
+  const cfg = { playerSpeed: 0.2, bulletSpeed: 0.5, grappleRange: 5 };
+  try {
+    const data = fs.readFileSync(file, 'utf8');
+    data.split(/\r?\n/).forEach(line => {
+      const t = line.trim();
+      if (!t || t.startsWith('#')) return;
+      const [k, v] = t.split(/:\s*/);
+      cfg[k] = parseFloat(v);
+    });
+  } catch (_) {}
+  return cfg;
+}
+
+const config = loadConfig();
+const PLAYER_SPEED = config.playerSpeed;
+const BULLET_SPEED = config.bulletSpeed;
+const GRAPPLE_RANGE = config.grappleRange;
 const players = {};
 const bullets = [];
 let nextPlayerId = 1;
@@ -114,7 +135,7 @@ function handleAction(id, action) {
     let dx=0,dy=0;
     if(dir==='up')dy=-1;else if(dir==='down')dy=1;else if(dir==='left')dx=-1;else if(dir==='right')dx=1;
     let cx=Math.floor(p.x), cy=Math.floor(p.y);
-    for(let i=0;i<5;i++){
+    for(let i=0;i<GRAPPLE_RANGE;i++){
       cx+=dx; cy+=dy;
       if(cx<0||cy<0||cx>=MAP_WIDTH||cy>=MAP_HEIGHT)break;
       if(map[cy][cx]===TILE_WALL){
@@ -128,4 +149,4 @@ function handleAction(id, action) {
 function gameState(){
   return {players, bullets, map};
 }
-module.exports={generateMap,addPlayer,removePlayer,handleAction,update,gameState,map,players,bullets};
+module.exports={generateMap,addPlayer,removePlayer,handleAction,update,gameState,map,players,bullets,config};

--- a/server/server.js
+++ b/server/server.js
@@ -21,7 +21,7 @@ function sendFile(res, filePath, contentType) {
 function handleJoin(req, res) {
   const player = game.addPlayer();
   res.writeHead(200, {'Content-Type': 'application/json'});
-  res.end(JSON.stringify({id: player.id, map: game.map}));
+  res.end(JSON.stringify({id: player.id, map: game.map, config: game.config}));
 }
 
 function handleStream(req, res, id) {


### PR DESCRIPTION
## Summary
- centralize gameplay constants in `server/config.yml`
- load config in the game server and expose values to clients
- use configurable grappling range on both server and client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852afc4c2088326aec22c116d322960