### PR TITLE
Enable grappling with arrow keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Open `http://localhost:3000` in your browser. You can also connect from other ma
 
 - **WASD** – move
 - **IJKL** – shoot in the four directions
-- **Space + IJKL** – grapple hook
+- **Arrow keys** – grapple hook
 
 Each player has a limited amount of HP (10 by default). Taking damage reduces HP by 1. Killing another player heals you, but HP never exceeds the maximum. Dying respawns you at a random location. The map scrolls with your character so only a small area is visible at once.
 
@@ -54,7 +54,8 @@ Client logic in `public/client.js` uses these endpoints to join the game, listen
 - Grapple hook that pulls the player next to the first wall in a direction
 - Basic sound effects and colored rectangles for graphics
 - Small death animation and visible health bars
-- Holding **space** shows the grappling hook range preview
+- Holding an **arrow key** shows the grappling hook range preview
+- Grapple cooldown displayed on screen
 - Large scrolling map with camera centered on the player
 - Smooth movement between grid cells
 - Browser zoom keys are disabled so everyone sees the same area

--- a/public/client.js
+++ b/public/client.js
@@ -96,8 +96,17 @@ function draw() {
   });
   animations = animations.filter(a=>a.t<10);
 
-  if(me && keys[' ']){
+  if(me && (keys['ArrowUp']||keys['ArrowDown']||keys['ArrowLeft']||keys['ArrowRight'])){
     drawGrapplePreview({x:mx,y:my}, camX, camY);
+  }
+  if(me){
+    const cd = config.grappleCooldown*1000 - (Date.now() - me.lastGrapple);
+    ctx.fillStyle='#fff';
+    ctx.font='16px sans-serif';
+    ctx.textBaseline='top';
+    ctx.textAlign='left';
+    if(cd<=0) ctx.fillText('Grapple ready',10,10);
+    else ctx.fillText('Grapple: '+Math.ceil(cd/1000)+'s',10,10);
   }
   requestAnimationFrame(draw);
 }
@@ -109,6 +118,7 @@ function send(action){
 function setupInput(){
   window.addEventListener('keydown',e=>{
     if(e.ctrlKey && ['-','_','+','=','0'].includes(e.key)) e.preventDefault();
+    if(['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.key)) e.preventDefault();
   });
   window.addEventListener('wheel',e=>{ if(e.ctrlKey) e.preventDefault(); },{passive:false});
   document.addEventListener('keydown',e=>{keys[e.key]=true;});
@@ -125,12 +135,10 @@ function setupInput(){
     if(keys['k']){send({type:'shoot',dir:'down'}); sndShoot.play();}
     if(keys['j']){send({type:'shoot',dir:'left'}); sndShoot.play();}
     if(keys['l']){send({type:'shoot',dir:'right'}); sndShoot.play();}
-    if(keys[' ']){
-      if(keys['i'])send({type:'grapple',dir:'up'});
-      if(keys['k'])send({type:'grapple',dir:'down'});
-      if(keys['j'])send({type:'grapple',dir:'left'});
-      if(keys['l'])send({type:'grapple',dir:'right'});
-    }
+    if(keys['ArrowUp'])send({type:'grapple',dir:'up'});
+    if(keys['ArrowDown'])send({type:'grapple',dir:'down'});
+    if(keys['ArrowLeft'])send({type:'grapple',dir:'left'});
+    if(keys['ArrowRight'])send({type:'grapple',dir:'right'});
   },100);
 }
 function drawGrapplePreview(me, camX, camY){


### PR DESCRIPTION
## Summary
- allow grappling via the arrow keys instead of Space+IJKL
- show a cooldown indicator on screen
- document new controls and cooldown display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852bc99cf748326acfdf7675a55f548