### PR TITLE
Add leaderboard overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Each player has a limited amount of HP (10 by default). Taking damage reduces HP
 
 Walls block bullets and can be grappled.
 
+At game start you will be prompted for your player name. A small leaderboard
+canvas sits in the top right corner showing all connected players ordered by
+their kill count. The red number next to each entry is the current kill streak
+(reset to zero when that player dies).
+
 ## Developer Guide
 
 ### Project layout

--- a/public/client.js
+++ b/public/client.js
@@ -1,9 +1,13 @@
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
+const board = document.getElementById('leaderboard');
+const bctx = board.getContext('2d');
 const tileSize = 16;
 function resize(){
   canvas.width = window.innerWidth;
   canvas.height = window.innerHeight;
+  board.width = 160;
+  board.height = 100;
 }
 window.addEventListener('resize', resize);
 resize();
@@ -99,6 +103,7 @@ function draw() {
   if(me && keys[' ']){
     drawGrapplePreview({x:mx,y:my}, camX, camY);
   }
+  drawLeaderboard();
   requestAnimationFrame(draw);
 }
 
@@ -147,8 +152,28 @@ function drawGrapplePreview(me, camX, camY){
   }
 }
 
+function drawLeaderboard(){
+  const arr = Object.values(players).sort((a,b)=> (b.score||0) - (a.score||0));
+  board.height = 20 + arr.length*14;
+  bctx.clearRect(0,0,board.width,board.height);
+  bctx.fillStyle = 'rgba(0,0,0,0.6)';
+  bctx.fillRect(0,0,board.width,board.height);
+  bctx.fillStyle='#fff';
+  bctx.font='12px sans-serif';
+  let y=14;
+  for(const p of arr){
+    bctx.fillStyle='#fff';
+    bctx.fillText(p.name||p.id,4,y);
+    bctx.fillText(String(p.score||0),100,y);
+    bctx.fillStyle='#f00';
+    bctx.fillText(String(p.streak||0),130,y);
+    y+=14;
+  }
+}
+
 function start(){
-  fetch('/join',{method:'POST'}).then(r=>r.json()).then(data=>{
+  const name = prompt('Enter your name');
+  fetch('/join',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name})}).then(r=>r.json()).then(data=>{
     playerId=data.id; map=data.map; config=data.config||config;
     lastHp = config.playerHp;
     const es=new EventSource('/stream?id='+playerId);

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
 <canvas id="game"></canvas>
+<canvas id="leaderboard"></canvas>
 <script src="client.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,2 +1,3 @@
 html,body { margin:0; padding:0; width:100%; height:100%; overflow:hidden; background:#111; color:white; font-family:sans-serif; }
 #game { display:block; margin:0; background:#222; width:100vw; height:100vh; }
+#leaderboard { position:absolute; top:0; right:0; pointer-events:none; }

--- a/server/game.js
+++ b/server/game.js
@@ -88,7 +88,7 @@ function generateMap() {
     }
   }
 }
-function addPlayer() {
+function addPlayer(name = 'Player') {
   let x, y;
   do {
     x = Math.floor(Math.random() * MAP_WIDTH);
@@ -97,10 +97,12 @@ function addPlayer() {
   const id = String(nextPlayerId++);
   players[id] = {
     id,
+    name,
     x: x + 0.5,
     y: y + 0.5,
     hp: PLAYER_HP,
     score: 0,
+    streak: 0,
     lastShoot: 0,
     lastGrapple: 0,
     grapple: null
@@ -141,8 +143,10 @@ function update() {
             if(killer){
               killer.hp = Math.min(killer.hp + REGEN_ON_KILL, PLAYER_HP);
               killer.score++;
+              killer.streak = (killer.streak || 0) + 1;
             }
             p.hp = PLAYER_HP;
+            p.streak = 0;
             let sx,sy;
             do{ sx=Math.floor(Math.random()*MAP_WIDTH); sy=Math.floor(Math.random()*MAP_HEIGHT);}while(map[sy][sx]!==TILE_EMPTY);
             p.x=sx+0.5; p.y=sy+0.5;

--- a/server/server.js
+++ b/server/server.js
@@ -19,9 +19,18 @@ function sendFile(res, filePath, contentType) {
 }
 
 function handleJoin(req, res) {
-  const player = game.addPlayer();
-  res.writeHead(200, {'Content-Type': 'application/json'});
-  res.end(JSON.stringify({id: player.id, map: game.map, config: game.config}));
+  let body='';
+  req.on('data', chunk => body += chunk);
+  req.on('end', () => {
+    let name = 'Player';
+    try {
+      const data = JSON.parse(body);
+      if (data.name) name = String(data.name).slice(0, 20);
+    } catch (_) {}
+    const player = game.addPlayer(name);
+    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.end(JSON.stringify({id: player.id, map: game.map, config: game.config}));
+  });
 }
 
 function handleStream(req, res, id) {


### PR DESCRIPTION
## Summary
- prompt for player name at startup
- track kills and killstreaks server side
- allow joining with a custom name
- overlay minimal leaderboard canvas on the client
- document leaderboard usage

## Testing
- `node -e "require('./server/server');"`

------
https://chatgpt.com/codex/tasks/task_e_6852bd2915e483268df911bf829946a5