### PR TITLE
Add auto-aim cone ability

### DIFF
--- a/server/config.yml
+++ b/server/config.yml
@@ -9,3 +9,7 @@ bulletDamage: 1
 playerHp: 10
 regenOnKill: 10
 grappleCooldown: 3
+# ability parameters
+abilityCooldown: 5
+abilityDamage: 6
+abilityRange: 4

--- a/server/server.js
+++ b/server/server.js
@@ -81,7 +81,7 @@ function serve(req, res) {
 game.generateMap();
 setInterval(()=>{
   game.update();
-  const state=JSON.stringify({type:'state', players: game.players, bullets: game.bullets});
+  const state=JSON.stringify({type:'state', players: game.players, bullets: game.bullets, cones: game.cones});
   for (const [id, res] of clients.entries()) {
     res.write(`data: ${state}\n\n`);
   }


### PR DESCRIPTION
## Summary
- add ability parameters to configuration
- implement server-side cone ability with cooldown
- send cone effects to clients
- render cone attack and cooldown text in client
- trigger ability with Enter key
- extend cone lifetime to a full second

## Testing
- `node server/server.js` *(started and terminated)*
- `npm test` *(fails: package.json missing at repo root)*
- `npm test` from `server/` *(starts server)*

------
https://chatgpt.com/codex/tasks/task_e_6852fecad7088326bdb99fb476b90834