### PR TITLE
Enable diagonal shots and grappling

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -171,20 +171,47 @@ function setupInput(){
     if(keys['a'])dx-=1;
     if(keys['d'])dx+=1;
     if(dx||dy) send({type:'move',dx,dy});
-    if(keys['i']){send({type:'shoot',dir:'up'}); sndShoot.play();}
-    if(keys['k']){send({type:'shoot',dir:'down'}); sndShoot.play();}
-    if(keys['j']){send({type:'shoot',dir:'left'}); sndShoot.play();}
-    if(keys['l']){send({type:'shoot',dir:'right'}); sndShoot.play();}
-    if(keys['ArrowUp'])send({type:'grapple',dir:'up'});
-    if(keys['ArrowDown'])send({type:'grapple',dir:'down'});
-    if(keys['ArrowLeft'])send({type:'grapple',dir:'left'});
-    if(keys['ArrowRight'])send({type:'grapple',dir:'right'});
+
+    // shooting (supports diagonal when multiple keys are pressed)
+    let sdx=0,sdy=0;
+    if(keys['i']) sdy-=1;
+    if(keys['k']) sdy+=1;
+    if(keys['j']) sdx-=1;
+    if(keys['l']) sdx+=1;
+    if(sdx||sdy){
+      let dir='';
+      if(sdy<0) dir+='up';
+      else if(sdy>0) dir+='down';
+      if(sdx<0) dir+='left';
+      else if(sdx>0) dir+='right';
+      send({type:'shoot',dir});
+      sndShoot.play();
+    }
+
+    // grappling (supports diagonal when multiple arrow keys are pressed)
+    let gdx=0,gdy=0;
+    if(keys['ArrowUp']) gdy-=1;
+    if(keys['ArrowDown']) gdy+=1;
+    if(keys['ArrowLeft']) gdx-=1;
+    if(keys['ArrowRight']) gdx+=1;
+    if(gdx||gdy){
+      let dir='';
+      if(gdy<0) dir+='up';
+      else if(gdy>0) dir+='down';
+      if(gdx<0) dir+='left';
+      else if(gdx>0) dir+='right';
+      send({type:'grapple',dir});
+    }
+
     if(keys['Enter'])send({type:'ability'});
   },100);
 }
 function drawGrapplePreview(me, camX, camY){
   ctx.fillStyle='rgba(255,255,255,0.3)';
-  const dirs=[{x:0,y:-1},{x:0,y:1},{x:-1,y:0},{x:1,y:0}];
+  const dirs=[
+    {x:0,y:-1},{x:0,y:1},{x:-1,y:0},{x:1,y:0},
+    {x:-1,y:-1},{x:1,y:-1},{x:-1,y:1},{x:1,y:1}
+  ];
   for(const d of dirs){
     let cx=Math.floor(me.x), cy=Math.floor(me.y);
     for(let i=0;i<(config.grappleRange||5);i++){

--- a/server/game.js
+++ b/server/game.js
@@ -122,11 +122,16 @@ function addBullet(ownerId, dir) {
   if (now - owner.lastShoot < RELOAD_TIME) return;
   owner.lastShoot = now;
   const speed = BULLET_SPEED;
+  const diag = speed/Math.SQRT2;
   const vel = {x:0,y:0};
   if (dir==='up') vel.y=-speed;
   else if (dir==='down') vel.y=speed;
   else if (dir==='left') vel.x=-speed;
   else if (dir==='right') vel.x=speed;
+  else if (dir==='upleft'){ vel.x=-diag; vel.y=-diag; }
+  else if (dir==='upright'){ vel.x=diag; vel.y=-diag; }
+  else if (dir==='downleft'){ vel.x=-diag; vel.y=diag; }
+  else if (dir==='downright'){ vel.x=diag; vel.y=diag; }
   bullets.push({x:owner.x, y:owner.y, vx:vel.x, vy:vel.y, owner:ownerId});
 }
 
@@ -249,7 +254,14 @@ function handleAction(id, action) {
     if (now - p.lastGrapple < GRAPPLE_COOLDOWN || p.grapple) return;
     const dir = action.dir;
     let dx=0,dy=0;
-    if(dir==='up')dy=-1;else if(dir==='down')dy=1;else if(dir==='left')dx=-1;else if(dir==='right')dx=1;
+    if(dir==='up')dy=-1;
+    else if(dir==='down')dy=1;
+    else if(dir==='left')dx=-1;
+    else if(dir==='right')dx=1;
+    else if(dir==='upleft'){dx=-1;dy=-1;}
+    else if(dir==='upright'){dx=1;dy=-1;}
+    else if(dir==='downleft'){dx=-1;dy=1;}
+    else if(dir==='downright'){dx=1;dy=1;}
     let cx=Math.floor(p.x), cy=Math.floor(p.y);
     for(let i=0;i<GRAPPLE_RANGE;i++){
       cx+=dx; cy+=dy;


### PR DESCRIPTION
## Summary
- support diagonal input for shooting and grappling
- draw diagonal grapple preview lines
- send diagonal bullet velocities server side

## Testing
- `npm test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685305eaf0708326ac23f337eb9fe7d0