### PR TITLE
Improve sound playback

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -40,12 +40,11 @@ let config = {
   abilityDamage: 6,
   abilityRange: 4
 };
-const sndShoot = new Audio('assets/gunshot.wav');
-const sndKill = new Audio('assets/laser_pew.wav');
-const sndDie = new Audio('assets/player_death_scream.wav');
-const sndGrapple = new Audio('assets/grappling_hook_zzzzup.wav');
+const sndShoot = document.getElementById('sndShoot');
+const sndKill = document.getElementById('sndKill');
+const sndDie = document.getElementById('sndDie');
+const sndGrapple = document.getElementById('sndGrapple');
 [sndShoot, sndKill, sndDie, sndGrapple].forEach(s => { s.volume = 1; });
-sndGrapple.loop = true;
 
 function draw() {
   ctx.clearRect(0,0,canvas.width,canvas.height);

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,10 @@
 <body>
 <canvas id="game"></canvas>
 <canvas id="leaderboard"></canvas>
+<audio id="sndShoot" src="assets/gunshot.wav" preload="auto"></audio>
+<audio id="sndKill" src="assets/laser_pew.wav" preload="auto"></audio>
+<audio id="sndDie" src="assets/player_death_scream.wav" preload="auto"></audio>
+<audio id="sndGrapple" src="assets/grappling_hook_zzzzup.wav" preload="auto" loop></audio>
 <script src="client.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- hook up audio tags in HTML
- play sounds via existing elements instead of creating new Audio objects

## Testing
- `node server/server.js` (briefly starts server without error)

------
https://chatgpt.com/codex/tasks/task_e_6853c28af850832695bc6fec063399db