### PR TITLE
Add class configs and selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Each player has a limited amount of HP (10 by default). Taking damage reduces HP
 
 Walls block bullets and can be grappled.
 
-At game start you will be prompted for your player name. A small leaderboard
-canvas sits in the top right corner showing all connected players ordered by
+At game start you will be prompted for your player name and to choose a class.
+A small leaderboard canvas sits in the top right corner showing all connected players ordered by
 their kill count. The red number next to each entry is the current kill streak
 (reset to zero when that player dies).
 
@@ -44,8 +44,8 @@ public/       - client side assets
 server/       - Node.js backend
   server.js   - HTTP server and event stream
   game.js     - game state and rules
-  config.js   - loads values from config.yml
-  config.yml  - gameplay parameters
+  config.js   - loads values from configs/*.yml
+  configs/    - game.yml and class configuration files
   package.json
 ```
 
@@ -75,7 +75,7 @@ Client logic in `public/client.js` uses these endpoints to join the game, listen
 
 ### Modifying the game
 
-- **Changing map size or player stats** – tweak values in `server/config.yml` (loaded by `server/config.js`).
+- **Changing map size or player stats** – tweak values in the files under `server/configs/` (loaded by `server/config.js`).
 - **Game logic implementation** – handled in `addPlayer`, `update` and `handleAction` inside `server/game.js`.
 - **Client rendering** – update canvas drawing code or add sprites in `public/client.js` and assets under `public/`.
 - **Camera behaviour** – the view follows the current player, computed in `draw()` inside `public/client.js`.

--- a/public/client.js
+++ b/public/client.js
@@ -261,7 +261,8 @@ function drawLeaderboard(){
 
 function start(){
   const name = prompt('Enter your name');
-  fetch('/join',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name})}).then(r=>r.json()).then(data=>{
+  const cls = prompt('Choose your class (class1, class2, class3)') || 'class1';
+  fetch('/join',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name, class: cls})}).then(r=>r.json()).then(data=>{
     playerId=data.id; map=data.map; config=data.config||config;
     lastHp = config.playerHp;
     const es=new EventSource('/stream?id='+playerId);

--- a/server/config.js
+++ b/server/config.js
@@ -1,24 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 
-function loadConfig() {
-  const file = path.join(__dirname, 'config.yml');
-  const cfg = {
-    playerSpeed: 0.2,
-    bulletSpeed: 0.5,
-    reloadTime: 0.3,
-    grappleSpeed: 1,
-    grappleRange: 5,
-    mapWidth: 100,
-    mapHeight: 50,
-    bulletDamage: 1,
-    playerHp: 10,
-    regenOnKill: 10,
-    grappleCooldown: 5,
-    abilityCooldown: 5,
-    abilityDamage: 6,
-    abilityRange: 4
-  };
+const CONFIG_DIR = path.join(__dirname, 'configs');
+
+function parseFile(file) {
+  const cfg = {};
   try {
     const data = fs.readFileSync(file, 'utf8');
     data.split(/\r?\n/).forEach(line => {
@@ -31,4 +17,16 @@ function loadConfig() {
   return cfg;
 }
 
-module.exports = loadConfig();
+function loadConfigs() {
+  const files = fs.readdirSync(CONFIG_DIR);
+  const game = parseFile(path.join(CONFIG_DIR, 'game.yml'));
+  const classes = {};
+  files.forEach(f => {
+    if (f === 'game.yml' || !f.endsWith('.yml')) return;
+    const name = f.replace(/\.yml$/, '');
+    classes[name] = parseFile(path.join(CONFIG_DIR, f));
+  });
+  return { game, classes };
+}
+
+module.exports = loadConfigs();

--- a/server/configs/class1.yml
+++ b/server/configs/class1.yml
@@ -3,13 +3,10 @@ bulletSpeed: 2.5
 reloadTime: 0.3
 grappleSpeed: 2
 grappleRange: 15
-mapWidth: 100
-mapHeight: 50
 bulletDamage: 1
 playerHp: 10
 regenOnKill: 10
 grappleCooldown: 3
-# ability parameters
 abilityCooldown: 5
 abilityDamage: 6
 abilityRange: 4

--- a/server/configs/class2.yml
+++ b/server/configs/class2.yml
@@ -1,0 +1,12 @@
+playerSpeed: 0.8
+bulletSpeed: 2.5
+reloadTime: 0.3
+grappleSpeed: 2
+grappleRange: 15
+bulletDamage: 1
+playerHp: 10
+regenOnKill: 10
+grappleCooldown: 3
+abilityCooldown: 5
+abilityDamage: 6
+abilityRange: 4

--- a/server/configs/class3.yml
+++ b/server/configs/class3.yml
@@ -1,0 +1,12 @@
+playerSpeed: 0.8
+bulletSpeed: 2.5
+reloadTime: 0.3
+grappleSpeed: 2
+grappleRange: 15
+bulletDamage: 1
+playerHp: 10
+regenOnKill: 10
+grappleCooldown: 3
+abilityCooldown: 5
+abilityDamage: 6
+abilityRange: 4

--- a/server/configs/game.yml
+++ b/server/configs/game.yml
@@ -1,0 +1,2 @@
+mapWidth: 100
+mapHeight: 50

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const url = require('url');
 const path = require('path');
 const game = require('./game');
+const configs = require('./config');
 
 const clients = new Map();
 const PORT = 3000;
@@ -23,13 +24,16 @@ function handleJoin(req, res) {
   req.on('data', chunk => body += chunk);
   req.on('end', () => {
     let name = 'Player';
+    let cls = 'class1';
     try {
       const data = JSON.parse(body);
       if (data.name) name = String(data.name).slice(0, 20);
+      if (data.class) cls = String(data.class);
     } catch (_) {}
-    const player = game.addPlayer(name);
+    const player = game.addPlayer(name, cls);
+    const playerCfg = Object.assign({}, configs.game, configs.classes[cls] || configs.classes[Object.keys(configs.classes)[0]]);
     res.writeHead(200, {'Content-Type': 'application/json'});
-    res.end(JSON.stringify({id: player.id, map: game.map, config: game.config}));
+    res.end(JSON.stringify({id: player.id, map: game.map, config: playerCfg}));
   });
 }
 


### PR DESCRIPTION
## Summary
- support multiple player classes
- split `config.yml` into `configs` folder
- load global and class configs in `config.js`
- allow class selection in client popup and server join
- store stats per-player to prepare for unique classes
- document new structure in README

## Testing
- `npm test` *(fails: opens server but requires manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_6853e6ae15d48326b75a13028d0a33e2